### PR TITLE
feat: add hive-microservice-mcp template (+ grpc Grpc.AspNetCore 2.80.0 fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         - microservice-graphql-api
         - microservice-grpc-api
         - microservice-grpc-minimal-api
+        - microservice-mcp
         os:
         - ubuntu-latest
         # - windows-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Templates:
 - `microservice-graphql-api` → `hive-microservice-graphql-api` (HotChocolate)
 - `microservice-grpc-api` → `hive-microservice-grpc-api` (gRPC, `.proto`-first)
 - `microservice-grpc-minimal-api` → `hive-microservice-grpc-minimal-api` (gRPC, code-first)
+- `microservice-mcp` → `hive-microservice-mcp` (Model Context Protocol server, attribute-discovered tools)
 
 ## Common commands
 
@@ -28,7 +29,7 @@ dotnet new -i ./<template-folder>
 dotnet new hive-<template-name> -pr <ProjectName> -svc <ServiceName> [--solution false]
 ```
 
-Run the full Pester test suite (runs against all 7 templates):
+Run the full Pester test suite (runs against all 8 templates):
 ```pwsh
 ./Tests.ps1
 ```

--- a/Install-Templates.ps1
+++ b/Install-Templates.ps1
@@ -9,6 +9,7 @@ $ErrorActionPreference = "Stop"
   "microservice-graphql-api"
   "microservice-grpc-api"
   "microservice-grpc-minimal-api"
+  "microservice-mcp"
 );
 
 $templates | % {

--- a/README.md
+++ b/README.md
@@ -92,3 +92,18 @@ dotnet new hive-microservice-grpc-api -pr <ProjectName> -svc <ServiceName> --sol
 ```bash
 dotnet new hive-microservice-minimal-grpc-api -pr <ProjectName> -svc <ServiceName> --solution (optional) 
 ```
+
+### hive-microservice-mcp
+
+> **Description**
+>
+> The `hive-microservice-mcp` is a long-running [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server, which exposes tools, prompts and resources to LLM clients and agents over streamable HTTP. Tool handlers are dependency-injected and discovered via `[McpServerTool]` attributes.
+>
+> Primary uses:
+> - AI tool servers
+> - Agentic integrations exposing data/actions to LLM clients
+
+**Service creation:**
+```bash
+dotnet new hive-microservice-mcp -pr <ProjectName> -svc <ServiceName> --solution (optional) 
+```

--- a/Templates.Tests.ps1
+++ b/Templates.Tests.ps1
@@ -13,7 +13,8 @@ Describe -tag "template-rendering" -Name "template-rendering tests" {
     @{ "SVC" = "microservice-minimal-api" },
     @{ "SVC" = "microservice-graphql-api" },
     @{ "SVC" = "microservice-grpc-api" },
-    @{ "SVC" = "microservice-grpc-minimal-api" }
+    @{ "SVC" = "microservice-grpc-minimal-api" },
+    @{ "SVC" = "microservice-mcp" }
   ) {
     Start-TemplateRenderingTest -Type $SVC -Solution $true -Root $PSScriptRoot;
   }
@@ -25,7 +26,8 @@ Describe -tag "template-rendering" -Name "template-rendering tests" {
     @{ "SVC" = "microservice-minimal-api" },
     @{ "SVC" = "microservice-graphql-api" },
     @{ "SVC" = "microservice-grpc-api" },
-    @{ "SVC" = "microservice-grpc-minimal-api" }
+    @{ "SVC" = "microservice-grpc-minimal-api" },
+    @{ "SVC" = "microservice-mcp" }
   ) {
     Start-TemplateRenderingTest -Type $SVC -Solution $false -Root $PSScriptRoot;
   }
@@ -39,7 +41,8 @@ Describe -tag "template-build" -Name "template building tests" {
     @{ "SVC" = "microservice-minimal-api" },
     @{ "SVC" = "microservice-graphql-api" },
     @{ "SVC" = "microservice-grpc-api" },
-    @{ "SVC" = "microservice-grpc-minimal-api" }
+    @{ "SVC" = "microservice-grpc-minimal-api" },
+    @{ "SVC" = "microservice-mcp" }
   ) {
     Start-TemplateBuildTest -Type $SVC -Root $PSScriptRoot;
   }
@@ -53,7 +56,8 @@ Describe -tag "template-run" -Name "template run tests" {
     @{ "SVC" = "microservice-minimal-api" },
     @{ "SVC" = "microservice-graphql-api" },
     @{ "SVC" = "microservice-grpc-api" },
-    @{ "SVC" = "microservice-grpc-minimal-api" }
+    @{ "SVC" = "microservice-grpc-minimal-api" },
+    @{ "SVC" = "microservice-mcp" }
   ) {
     Start-TemplateRunTest -Type $SVC -Root $PSScriptRoot;
   }

--- a/microservice-grpc-api/src/ProjectName.ServiceName.Grpc/ProjectName.ServiceName.Grpc.csproj
+++ b/microservice-grpc-api/src/ProjectName.ServiceName.Grpc/ProjectName.ServiceName.Grpc.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
+        <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
     </ItemGroup>
 
 

--- a/microservice-grpc-minimal-api/src/ProjectName.ServiceName.Grpc/ProjectName.ServiceName.Grpc.csproj
+++ b/microservice-grpc-minimal-api/src/ProjectName.ServiceName.Grpc/ProjectName.ServiceName.Grpc.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
+        <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
     </ItemGroup>
 
 

--- a/microservice-mcp/.editorconfig
+++ b/microservice-mcp/.editorconfig
@@ -1,0 +1,138 @@
+root = true
+
+[*.cs]
+trim_trailing_whitespace = true
+
+dotnet_diagnostic.AsyncFixer01.severity = suggestion    # AsyncFixer01: Unnecessary async/await usage
+dotnet_diagnostic.AsyncFixer02.severity = error         # AsyncFixer02: Long-running or blocking operations inside an async method
+dotnet_diagnostic.AsyncFixer03.severity = error         # AsyncFixer03: Fire & forget async void methods
+dotnet_diagnostic.AsyncFixer04.severity = error         # AsyncFixer04: Fire & forget async call inside a using block
+
+dotnet_diagnostic.AsyncifyInvocation.severity = error   # AsyncifyInvocation: Use Task Async
+dotnet_diagnostic.AsyncifyVariable.severity = error     # AsyncifyVariable: Use Task Async
+
+dotnet_diagnostic.VSTHRD002.severity = error    # VSTHRD002: Avoid problematic synchronous waits
+dotnet_diagnostic.VSTHRD100.severity = error    # VSTHRD100: Avoid async void methods
+dotnet_diagnostic.VSTHRD101.severity = error    # VSTHRD101: Avoid unsupported async delegates
+dotnet_diagnostic.VSTHRD103.severity = error    # VSTHRD103: Call async methods when in an async method
+dotnet_diagnostic.VSTHRD107.severity = error    # VSTHRD107: Await Task within using expression
+dotnet_diagnostic.VSTHRD110.severity = error    # VSTHRD110: Observe result of async calls
+dotnet_diagnostic.VSTHRD111.severity = none     # VSTHRD111: Use ConfigureAwait(bool)
+dotnet_diagnostic.VSTHRD114.severity = error    # VSTHRD114: Avoid returning a null Task
+dotnet_diagnostic.VSTHRD200.severity = none     # VSTHRD200: Use "Async" suffix for async methods
+
+#AsyncFixer05: Downcasting from a nested task to an outer task.
+dotnet_diagnostic.AsyncFixer05.severity = error
+
+dotnet_diagnostic.MA0001.severity = none       # MA0001: StringComparison is missing
+dotnet_diagnostic.MA0002.severity = none       # MA0002: IEqualityComparer<string> or IComparer<string> is missing
+dotnet_diagnostic.MA0003.severity = none       # MA0003: Add argument name to improve readability
+dotnet_diagnostic.MA0004.severity = none       # MA0004: Use Task.ConfigureAwait(false)
+dotnet_diagnostic.MA0005.severity = none       # MA0005: Use Array.Empty<T>()
+dotnet_diagnostic.MA0006.severity = none       # MA0006: Use String.Equals instead of equality operator
+dotnet_diagnostic.MA0007.severity = none       # MA0007: Add a comma after the last value
+dotnet_diagnostic.MA0008.severity = none       # MA0008: Add StructLayoutAttribute
+dotnet_diagnostic.MA0009.severity = none       # MA0009: Add regex evaluation timeout
+dotnet_diagnostic.MA0010.severity = warning    # MA0010: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.MA0011.severity = none       # MA0011: IFormatProvider is missing
+dotnet_diagnostic.MA0012.severity = none       # MA0012: Do not raise reserved exception type
+dotnet_diagnostic.MA0013.severity = none       # MA0013: Types should not extend System.ApplicationException
+dotnet_diagnostic.MA0014.severity = none       # MA0014: Do not raise System.ApplicationException type
+dotnet_diagnostic.MA0015.severity = warning    # MA0015: Specify the parameter name in ArgumentException
+dotnet_diagnostic.MA0016.severity = none       # MA0016: Prefer return collection abstraction instead of implementation
+dotnet_diagnostic.MA0017.severity = none       # MA0017: Abstract types should not have public or internal constructors
+dotnet_diagnostic.MA0018.severity = none       # MA0018: Do not declare static members on generic types
+dotnet_diagnostic.MA0019.severity = none       # MA0019: Use EventArgs.Empty
+dotnet_diagnostic.MA0020.severity = none       # MA0020: Use direct methods instead of LINQ methods
+dotnet_diagnostic.MA0021.severity = none       # MA0021: Use StringComparer.GetHashCode instead of string.GetHashCode
+dotnet_diagnostic.MA0022.severity = error      # MA0022: Return Task.FromResult instead of returning null
+dotnet_diagnostic.MA0023.severity = none       # MA0023: Add RegexOptions.ExplicitCapture
+dotnet_diagnostic.MA0024.severity = none       # MA0024: Use an explicit StringComparer when possible
+dotnet_diagnostic.MA0025.severity = none       # MA0025: Implement the functionality instead of throwing NotImplementedException
+dotnet_diagnostic.MA0026.severity = none       # MA0026: Fix TODO comment
+dotnet_diagnostic.MA0027.severity = none       # MA0027: Do not remove original exception
+dotnet_diagnostic.MA0028.severity = none       # MA0028: Optimize StringBuilder usage
+dotnet_diagnostic.MA0029.severity = none       # MA0029: Combine LINQ methods
+dotnet_diagnostic.MA0030.severity = none       # MA0030: Remove useless OrderBy call
+dotnet_diagnostic.MA0031.severity = none       # MA0031: Optimize Enumerable.Count() usage
+dotnet_diagnostic.MA0032.severity = warning    # MA0032: Use an overload with a CancellationToken argument
+dotnet_diagnostic.MA0033.severity = none       # MA0033: Do not tag instance fields with ThreadStaticAttribute
+dotnet_diagnostic.MA0035.severity = none       # MA0035: Do not use dangerous threading methods
+dotnet_diagnostic.MA0036.severity = suggestion # MA0036: Make class static
+dotnet_diagnostic.MA0037.severity = suggestion # MA0037: Remove empty statement
+dotnet_diagnostic.MA0038.severity = suggestion # MA0038: Make method static
+dotnet_diagnostic.MA0039.severity = error      # MA0039: Do not write your own certificate validation method
+dotnet_diagnostic.MA0040.severity = error      # MA0040: Flow the cancellation token
+dotnet_diagnostic.MA0041.severity = suggestion # MA0041: Make property static
+dotnet_diagnostic.MA0042.severity = error      # MA0042: Do not use blocking calls in an async method
+dotnet_diagnostic.MA0043.severity = warning    # MA0043: Use nameof operator in ArgumentException
+dotnet_diagnostic.MA0044.severity = none       # MA0044: Remove useless ToString call
+dotnet_diagnostic.MA0045.severity = error      # MA0045: Do not use blocking call in a sync method (need to make containing method async)
+dotnet_diagnostic.MA0046.severity = none       # MA0046: Use EventHandler<T> to declare events
+dotnet_diagnostic.MA0047.severity = warning    # MA0047: Declare types in namespaces
+dotnet_diagnostic.MA0048.severity = none       # MA0048: File name must match type name
+dotnet_diagnostic.MA0049.severity = suggestion # MA0049: Type name should not match containing namespace
+dotnet_diagnostic.MA0050.severity = suggestion # MA0050: Validate arguments correctly in iterator methods
+dotnet_diagnostic.MA0051.severity = warning    # MA0051: Method is too long
+dotnet_diagnostic.MA0052.severity = suggestion # MA0052: Replace constant Enum.ToString with nameof
+dotnet_diagnostic.MA0053.severity = suggestion # MA0053: Make class sealed
+dotnet_diagnostic.MA0054.severity = warning    # MA0054: Embed the caught exception as innerException
+dotnet_diagnostic.MA0055.severity = warning    # MA0055: Do not use finalizer
+dotnet_diagnostic.MA0056.severity = warning    # MA0056: Do not call overridable members in constructor
+dotnet_diagnostic.MA0057.severity = error      # MA0057: Class name should end with 'Attribute'
+dotnet_diagnostic.MA0058.severity = error      # MA0058: Class name should end with 'Exception'
+dotnet_diagnostic.MA0059.severity = none       # MA0059: Class name should end with 'EventArgs'
+dotnet_diagnostic.MA0060.severity = suggestion # MA0060: The value returned by Stream.Read/Stream.ReadAsync is not used
+dotnet_diagnostic.MA0061.severity = error      # MA0061: Method overrides should not change parameter defaults
+dotnet_diagnostic.MA0062.severity = none       # MA0062: Non-flags enums should not be marked with "FlagsAttribute"
+dotnet_diagnostic.MA0063.severity = none       # MA0063: Use Where before OrderBy
+dotnet_diagnostic.MA0064.severity = none       # MA0064: Avoid locking on publicly accessible instance
+dotnet_diagnostic.MA0065.severity = none       # MA0065: Default ValueType.Equals or HashCode is used for struct's equality
+dotnet_diagnostic.MA0066.severity = suggestion # MA0066: Hash table unfriendly type is used in a hash table
+dotnet_diagnostic.MA0067.severity = none       # MA0067: Use Guid.Empty
+dotnet_diagnostic.MA0068.severity = none       # MA0068: Invalid parameter name for nullable attribute
+dotnet_diagnostic.MA0069.severity = none       # MA0069: Non-constant static fields should not be visible
+dotnet_diagnostic.MA0070.severity = error      # MA0070: Obsolete attributes should include explanations
+dotnet_diagnostic.MA0071.severity = warning    # MA0071: Avoid using redundant else
+dotnet_diagnostic.MA0072.severity = warning    # MA0072: Do not throw from a finally block
+dotnet_diagnostic.MA0073.severity = suggestion # MA0073: Avoid comparison with bool constant
+dotnet_diagnostic.MA0074.severity = none       # MA0074: Avoid implicit culture-sensitive methods
+dotnet_diagnostic.MA0075.severity = none       # MA0075: Do not use implicit culture-sensitive ToString
+dotnet_diagnostic.MA0076.severity = none       # MA0076: Do not use implicit culture-sensitive ToString in interpolated strings
+dotnet_diagnostic.MA0077.severity = none       # MA0077: A class that provides Equals(T) should implement IEquatable<T>
+dotnet_diagnostic.MA0078.severity = none       # MA0078: Use 'Cast' instead of 'Select' to cast
+dotnet_diagnostic.MA0079.severity = error      # MA0079: Flow the cancellation token using .WithCancellation()
+dotnet_diagnostic.MA0080.severity = error      # MA0080: Use a cancellation token using .WithCancellation()
+dotnet_diagnostic.MA0081.severity = none       # MA0081: Method overrides should not omit params keyword
+dotnet_diagnostic.MA0082.severity = none       # MA0082: NaN should not be used in comparisons
+dotnet_diagnostic.MA0083.severity = none       # MA0083: ConstructorArgument parameters should exist in constructors
+dotnet_diagnostic.MA0084.severity = none       # MA0084: Local variable should not hide other symbols
+dotnet_diagnostic.MA0085.severity = none       # MA0085: Anonymous delegates should not be used to unsubscribe from Events
+dotnet_diagnostic.MA0086.severity = error      # MA0086: Do not throw from a finalizer
+dotnet_diagnostic.MA0087.severity = none       # MA0087: Parameters with [DefaultParameterValue] attributes should also be marked [Optional]
+dotnet_diagnostic.MA0088.severity = none       # MA0088: Use [DefaultParameterValue] instead of [DefaultValue]
+dotnet_diagnostic.MA0089.severity = error      # MA0089: Optimize string method usage
+dotnet_diagnostic.MA0090.severity = error      # MA0090: Remove empty else/finally block
+dotnet_diagnostic.MA0091.severity = none       # MA0091: Sender should be 'this' for instance events
+dotnet_diagnostic.MA0092.severity = none       # MA0092: Sender should be 'null' for static events
+dotnet_diagnostic.MA0093.severity = none       # MA0093: EventArgs should not be null
+dotnet_diagnostic.MA0094.severity = none       # MA0094: A class that provides CompareTo(T) should implement IComparable<T>
+dotnet_diagnostic.MA0095.severity = none       # MA0095: A class that implements IEquatable<T> should override Equals(object)
+dotnet_diagnostic.MA0096.severity = none       # MA0096: A class that implements IComparable<T> should also implement IEquatable<T>
+dotnet_diagnostic.MA0097.severity = none       # MA0097: A class that implements IComparable<T> or IComparable should override comparison operators
+dotnet_diagnostic.MA0098.severity = none       # MA0098: Use indexer instead of LINQ methods
+dotnet_diagnostic.MA0099.severity = none       # MA0099: Use Explicit enum value instead of 0
+dotnet_diagnostic.MA0100.severity = none       # MA0100: Await task before disposing resources
+dotnet_diagnostic.MA0101.severity = none       # MA0101: String contains an implicit end of line character
+dotnet_diagnostic.MA0102.severity = suggestion # MA0102: Make member readonly
+
+# Ignore some analyzers:
+# [src/<SomeService>/<Path>/*.cs]
+# dotnet_diagnostic.MA0045.severity = none       # MA0045: Do not use blocking call in a sync method (need to make containing method async)
+# [src/<SomeService>/<Path>/*.cs]
+# dotnet_diagnostic.MA0032.severity = none       # MA0032: Use an overload with a CancellationToken argument
+
+# Temporarily ignore "method too long warning":
+# [src/<SomeService>/<Path>/*.cs]
+# dotnet_diagnostic.MA0051.severity = none    # MA0051: Method is too long
+

--- a/microservice-mcp/.template.config/dotnetcli.host.json
+++ b/microservice-mcp/.template.config/dotnetcli.host.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "project": {
+      "longName": "project",
+      "shortName": "pr"
+    },
+    "service": {
+      "longName": "service",
+      "shortName": "svc"
+    }
+  }
+}

--- a/microservice-mcp/.template.config/template.json
+++ b/microservice-mcp/.template.config/template.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "CloudTek",
+  "classifications": ["Hive", "MicroService.Mcp"],
+  "identity": "Hive.MicroService.Mcp",
+  "name": "Hive MicroService MCP",
+  "shortName": "hive-microservice-mcp",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "symbols": {
+    "project": {
+      "description": "Project name",
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "ProjectName",
+      "fileRename": "ProjectName",
+      "defaultValue": "CloudTek"
+    },
+    "projectLowercase": {
+      "type": "generated",
+      "generator": "casing",
+      "parameters": {
+        "source": "project",
+        "toLower": true
+      },
+      "replaces": "ProjectNameLower",
+      "fileRename": "ProjectNameLower"
+    },
+    "service": {
+      "description": "Service name",
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "ServiceName",
+      "fileRename": "ServiceName",
+      "defaultValue": "Service"
+    },
+    "serviceLowercase": {
+      "type": "generated",
+      "generator": "casing",
+      "parameters": {
+        "source": "service",
+        "toLower": true
+      },
+      "replaces": "ServiceNameLower",
+      "fileRename": "ServiceNameLower"
+    },
+    "solution": {
+      "type": "parameter",
+      "datatype":"bool",
+      "defaultValue": "true"
+    }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!solution)",
+          "exclude": [
+            "readme.md"
+          ]
+        },
+        {
+          "condition": "(!solution)",
+          "exclude": [
+            "LICENSE"
+          ]
+        },
+        {
+          "condition": "(!solution)",
+          "exclude": [
+            ".editorconfig"
+          ]
+        },
+        {
+          "condition": "(!solution)",
+          "exclude": [
+            "*.sln"
+          ]
+        },
+        {
+          "exclude": [
+            "**/[Bb]in/**",
+            "**/[Oo]bj/**",
+            ".template.config/**/*",
+            "**/*.filelist",
+            "**/*.user",
+            "**/*.lock.json",
+            "**/.idea/**",
+            "Tests.ps1"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/microservice-mcp/LICENSE
+++ b/microservice-mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 cloud-tek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/microservice-mcp/ProjectName.ServiceName.sln
+++ b/microservice-mcp/ProjectName.ServiceName.sln
@@ -1,0 +1,24 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ProjectNameLower-ServiceNameLower-mcp", "ProjectNameLower-ServiceNameLower-mcp", "{40533937-B210-4F9E-9BE0-114AE555FE3F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{531C579D-15D0-4A8D-9C11-13D996E5A0EF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectName.ServiceName.Mcp", "src\ProjectName.ServiceName.Mcp\ProjectName.ServiceName.Mcp.csproj", "{342625F4-3A1D-44CE-BFF3-1BC4DFC45EB9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{342625F4-3A1D-44CE-BFF3-1BC4DFC45EB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{342625F4-3A1D-44CE-BFF3-1BC4DFC45EB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{342625F4-3A1D-44CE-BFF3-1BC4DFC45EB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{342625F4-3A1D-44CE-BFF3-1BC4DFC45EB9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{531C579D-15D0-4A8D-9C11-13D996E5A0EF} = {40533937-B210-4F9E-9BE0-114AE555FE3F}
+		{342625F4-3A1D-44CE-BFF3-1BC4DFC45EB9} = {531C579D-15D0-4A8D-9C11-13D996E5A0EF}
+	EndGlobalSection
+EndGlobal

--- a/microservice-mcp/readme.md
+++ b/microservice-mcp/readme.md
@@ -1,0 +1,32 @@
+# ProjectNameLower-ServiceNameLower-mcp
+
+## Gettings started
+
+```bash
+dotnet tool restore
+TODO: nuke
+```
+
+> TODO:
+>
+> required Hive settings
+
+## Useful links
+
+---
+
+## How do I...
+
+---
+
+## Swagger
+
+---
+
+# Build & Tests
+
+---
+
+# Contact & Support
+
+---

--- a/microservice-mcp/src/ProjectName.ServiceName.Mcp/Program.cs
+++ b/microservice-mcp/src/ProjectName.ServiceName.Mcp/Program.cs
@@ -1,0 +1,17 @@
+using Hive.MicroServices;
+using Hive.MicroServices.Extensions;
+using Hive.MicroServices.Mcp;
+using ProjectName.ServiceName.Mcp.Tools;
+using ProjectName.ServiceName.Mcp.Weather;
+
+var service = new MicroService("ProjectNameLower-ServiceNameLower-mcp")
+    .ConfigureServices((services, configuration) =>
+    {
+        services.AddSingleton<IWeatherForecastService, WeatherForecastService>();
+    })
+    .ConfigureMcpPipeline(mcp =>
+    {
+        mcp.WithTools<WeatherForecastTool>();
+    });
+
+await service.RunAsync();

--- a/microservice-mcp/src/ProjectName.ServiceName.Mcp/ProjectName.ServiceName.Mcp.csproj
+++ b/microservice-mcp/src/ProjectName.ServiceName.Mcp/ProjectName.ServiceName.Mcp.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14.0</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Hive.MicroServices.Mcp" Version="10.*" />
+    </ItemGroup>
+
+</Project>

--- a/microservice-mcp/src/ProjectName.ServiceName.Mcp/Properties/launchSettings.json
+++ b/microservice-mcp/src/ProjectName.ServiceName.Mcp/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "ProjectName.ServiceName.Mcp": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/microservice-mcp/src/ProjectName.ServiceName.Mcp/Tools/WeatherForecastTool.cs
+++ b/microservice-mcp/src/ProjectName.ServiceName.Mcp/Tools/WeatherForecastTool.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using ProjectName.ServiceName.Mcp.Weather;
+
+namespace ProjectName.ServiceName.Mcp.Tools;
+
+[McpServerToolType]
+public class WeatherForecastTool
+{
+    [McpServerTool(Name = "get_weather_forecast")]
+    [Description("Gets the weather forecast for the next few days")]
+    public static IEnumerable<WeatherForecast> GetWeatherForecast(IWeatherForecastService service)
+        => service.GetWeatherForecast();
+}

--- a/microservice-mcp/src/ProjectName.ServiceName.Mcp/Weather/IWeatherForecastService.cs
+++ b/microservice-mcp/src/ProjectName.ServiceName.Mcp/Weather/IWeatherForecastService.cs
@@ -1,0 +1,7 @@
+﻿namespace ProjectName.ServiceName.Mcp.Weather;
+
+public interface IWeatherForecastService
+{
+    IEnumerable<WeatherForecast> GetWeatherForecast();
+}
+

--- a/microservice-mcp/src/ProjectName.ServiceName.Mcp/Weather/WeatherForecast.cs
+++ b/microservice-mcp/src/ProjectName.ServiceName.Mcp/Weather/WeatherForecast.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace ProjectName.ServiceName.Mcp.Weather;
+
+public record WeatherForecast(DateTime Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/microservice-mcp/src/ProjectName.ServiceName.Mcp/Weather/WeatherForecastService.cs
+++ b/microservice-mcp/src/ProjectName.ServiceName.Mcp/Weather/WeatherForecastService.cs
@@ -1,0 +1,20 @@
+﻿namespace ProjectName.ServiceName.Mcp.Weather;
+
+public class WeatherForecastService : IWeatherForecastService
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    public IEnumerable<WeatherForecast> GetWeatherForecast()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast(
+        
+            DateTime.Now.AddDays(index),
+            Random.Shared.Next(-20, 55),
+            Summaries[Random.Shared.Next(Summaries.Length)]
+        ))
+        .ToArray();
+    }
+}

--- a/microservice-mcp/src/ProjectName.ServiceName.Mcp/appsettings.Development.json
+++ b/microservice-mcp/src/ProjectName.ServiceName.Mcp/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/microservice-mcp/src/ProjectName.ServiceName.Mcp/appsettings.json
+++ b/microservice-mcp/src/ProjectName.ServiceName.Mcp/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/scripts/TestSuite.psm1
+++ b/scripts/TestSuite.psm1
@@ -8,6 +8,7 @@ Import-Module "Pester";
   "microservice-graphql-api"    = "graphql-api"
   "microservice-grpc-api"         = "grpc-api"
   "microservice-grpc-minimal-api" = "grpc-api"
+  "microservice-mcp"              = "mcp"
 };
 
 [hashtable]$csprojSuffix = @{
@@ -18,6 +19,7 @@ Import-Module "Pester";
   "microservice-graphql-api"    = "GraphQL"
   "microservice-grpc-api"         = "Grpc"
   "microservice-grpc-minimal-api" = "Grpc"
+  "microservice-mcp"              = "Mcp"
 };
 
 function Start-TemplateRenderingTest {


### PR DESCRIPTION
## Summary

Adds an 8th \`dotnet new\` template for the new Hive **MCP** MicroService kind (\`Hive.MicroServices.Mcp\` 10.1.0.71), which exposes tools to LLM clients/agents over streamable HTTP. Also fixes a pre-existing build break in the two gRPC templates.

### New template — \`hive-microservice-mcp\`
- Modelled on \`microservice-grpc-minimal-api\`: a DI-registered \`Weather\` domain service + an attribute-discovered MCP tool (\`WeatherForecastTool\`, \`[McpServerTool]\` \`get_weather_forecast\`).
- Bootstrapped via \`ConfigureMcpPipeline(mcp => mcp.WithTools<WeatherForecastTool>())\`.
- Suffixes: \`.Mcp\` (assembly/folder/csproj), \`-mcp\` (service identifier).
- Single \`Hive.MicroServices.Mcp\` \`10.*\` package reference.
- Wired into every enumeration point so all four CI gates cover it: \`Install-Templates.ps1\`, \`scripts/TestSuite.psm1\` (suffix maps), \`Templates.Tests.ps1\` (render/build/run), \`.github/workflows/ci.yml\` (pre-build matrix), plus README/CLAUDE docs.

### gRPC fix
\`Hive.MicroServices.Grpc\` 10.1.0.71 requires \`Grpc.AspNetCore\` >= 2.80.0; the templates pinned 2.76.0, producing a fatal NU1605 downgrade error under \`TreatWarningsAsErrors\`. Bumped both to 2.80.0.

## Testing
Full local Pester suite: **32 passed, 0 failed** (all 8 templates × rendering ±solution / build / run). The mcp template passes in all four categories; the run test confirms it starts, serves \`/status/liveness\` (HTTP 200), and exits 0 on SIGTERM. The gRPC templates build and run again.